### PR TITLE
Build of static website from the reports

### DIFF
--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -3,7 +3,13 @@
 Build a MkDocs documentation site from the OSP-PBPK-Model-Library repository.
 
 Each top-level folder becomes a chapter. Markdown content is rendered as-is,
-with download buttons prepended for the PDF report and .pksim5 model files.
+with download buttons appended for the PDF report and .pksim5 model files.
+
+Site features:
+- OSP blue colour palette (matching docs.open-systems-pharmacology.org)
+- Hamburger navigation menu on all screen sizes (replaces top nav-tabs)
+- Floating sidebar table of contents on every report page
+- Home page listing all reports with PDF / pksim5 download links
 """
 
 import os
@@ -18,6 +24,105 @@ MKDOCS_YML = os.path.join(REPO_ROOT, "mkdocs.yml")
 # Folders to exclude (hidden directories and non-compound folders)
 EXCLUDE_PREFIXES = (".", "_")
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Extra CSS – injected into docs/stylesheets/extra.css
+# ──────────────────────────────────────────────────────────────────────────────
+EXTRA_CSS = """\
+/* ============================================================
+   OSP PBPK Model Library – Custom Styles
+   Colour palette inspired by docs.open-systems-pharmacology.org
+   ============================================================ */
+
+/* --- Primary colour: OSP blue -------------------------------- */
+:root,
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color:              #1565c0;
+  --md-primary-fg-color--light:       #1976d2;
+  --md-primary-fg-color--dark:        #0d47a1;
+  --md-accent-fg-color:               #2196f3;
+  --md-accent-fg-color--transparent:  rgba(33, 150, 243, .1);
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color:              #1976d2;
+  --md-primary-fg-color--light:       #42a5f5;
+  --md-primary-fg-color--dark:        #0d47a1;
+  --md-accent-fg-color:               #42a5f5;
+  --md-accent-fg-color--transparent:  rgba(66, 165, 245, .1);
+}
+
+/* --- Hamburger menu: visible on ALL screen sizes ------------- */
+@media screen and (min-width: 76.25em) {
+  /* Reveal the hamburger / drawer toggle button on desktop */
+  .md-header__button[for="__drawer"] {
+    display: inline-flex !important;
+  }
+
+  /* Slide the primary navigation sidebar out of view by default */
+  .md-sidebar--primary {
+    position:  fixed     !important;
+    top:       0         !important;
+    left:      0         !important;
+    width:     12.1rem   !important;
+    height:    100vh     !important;
+    z-index:   4         !important;
+    transform: translateX(-100%) !important;
+    transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+                box-shadow 0.25s ease !important;
+    box-shadow: none !important;
+    background: var(--md-default-bg-color) !important;
+    overflow-y: auto !important;
+  }
+
+  /* Slide in when the drawer checkbox is checked */
+  [data-md-toggle="drawer"]:checked ~ .md-container .md-sidebar--primary {
+    transform:  translateX(0) !important;
+    box-shadow: 0.2rem 0 0.8rem rgba(0, 0, 0, 0.25) !important;
+  }
+
+  /* Activate the dark overlay behind the open drawer */
+  [data-md-toggle="drawer"]:checked ~ .md-overlay {
+    opacity:        1    !important;
+    pointer-events: auto !important;
+  }
+
+  /* Content fills the full width when the sidebar is hidden */
+  .md-main__inner {
+    margin-left: 0 !important;
+  }
+
+  .md-content {
+    max-width: 56rem;
+    margin:    0 auto;
+  }
+}
+
+/* --- Floating / sticky table of contents --------------------- */
+@media screen and (min-width: 60em) {
+  .md-sidebar--secondary .md-sidebar__scrollwrap {
+    position:   sticky   !important;
+    top:        4rem     !important;
+    max-height: calc(100vh - 4.5rem) !important;
+    overflow-y: auto     !important;
+  }
+}
+
+/* Highlight the currently active TOC link */
+.md-nav--secondary .md-nav__link--active {
+  color:       var(--md-accent-fg-color) !important;
+  font-weight: 600;
+}
+
+/* --- Download section button spacing ------------------------- */
+.download-section .md-button {
+  margin: 0.2rem 0.4rem 0.2rem 0;
+}
+"""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
 
 def is_compound_folder(path: str) -> bool:
     """Return True if the folder contains a markdown evaluation report."""
@@ -27,8 +132,8 @@ def is_compound_folder(path: str) -> bool:
     return False
 
 
-def make_download_buttons(folder_name: str, pdf_files: list, pksim_files: list) -> str:
-    """Return an HTML block with download buttons for all assets."""
+def make_download_buttons(pdf_files: list, pksim_files: list) -> str:
+    """Return a Markdown block with download buttons for all assets."""
     lines = [
         "",
         '<div class="download-section" markdown="1">',
@@ -39,13 +144,15 @@ def make_download_buttons(folder_name: str, pdf_files: list, pksim_files: list) 
     for pdf in sorted(pdf_files):
         label = os.path.basename(pdf)
         lines.append(
-            f'[:material-file-pdf-box: Download PDF Report]({label}){{: .md-button download="{label}" }}'
+            f'[:material-file-pdf-box: Download PDF Report]({label})'
+            f'{{: .md-button download="{label}" }}'
         )
         lines.append("")
     for pksim in sorted(pksim_files):
         label = os.path.basename(pksim)
         lines.append(
-            f'[:material-download: Download PBPK Model ({label})]({label}){{: .md-button .md-button--primary download="{label}" }}'
+            f'[:material-download: Download PBPK Model ({label})]({label})'
+            f'{{: .md-button .md-button--primary download="{label}" }}'
         )
         lines.append("")
     lines.append("</div>")
@@ -53,14 +160,21 @@ def make_download_buttons(folder_name: str, pdf_files: list, pksim_files: list) 
     return "\n".join(lines)
 
 
-def process_folder(folder_path: str, folder_name: str):
-    """Copy and process one compound folder into docs/."""
+# ──────────────────────────────────────────────────────────────────────────────
+# Per-compound processing
+# ──────────────────────────────────────────────────────────────────────────────
+
+def process_folder(folder_path: str, folder_name: str) -> dict:
+    """Copy and process one compound folder into docs/.
+
+    Returns a dict with keys: name, pdf_files, pksim_files.
+    """
     dest = os.path.join(DOCS_DIR, folder_name)
     os.makedirs(dest, exist_ok=True)
 
     # Collect assets
-    md_files = glob.glob(os.path.join(folder_path, "*_evaluation_report.md"))
-    pdf_files = glob.glob(os.path.join(folder_path, "*.pdf"))
+    md_files   = glob.glob(os.path.join(folder_path, "*_evaluation_report.md"))
+    pdf_files  = glob.glob(os.path.join(folder_path, "*.pdf"))
     pksim_files = glob.glob(os.path.join(folder_path, "*.pksim5"))
     images_dir = os.path.join(folder_path, "images")
 
@@ -71,42 +185,78 @@ def process_folder(folder_path: str, folder_name: str):
             shutil.rmtree(dest_images)
         shutil.copytree(images_dir, dest_images)
 
-    # Copy PDF files
+    # Copy binary assets
     for pdf in pdf_files:
         shutil.copy2(pdf, dest)
-
-    # Copy .pksim5 files
     for pksim in pksim_files:
         shutil.copy2(pksim, dest)
 
-    # Process markdown — append download section
+    pdf_basenames   = sorted(os.path.basename(p) for p in pdf_files)
+    pksim_basenames = sorted(os.path.basename(p) for p in pksim_files)
+
+    download_block = make_download_buttons(pdf_basenames, pksim_basenames)
+
+    # Write index.md (report content + download section)
+    dest_md = os.path.join(dest, "index.md")
     if md_files:
-        md_src = md_files[0]
-        with open(md_src, "r", encoding="utf-8") as fh:
+        with open(md_files[0], "r", encoding="utf-8") as fh:
             content = fh.read()
-
-        download_block = make_download_buttons(
-            folder_name,
-            [os.path.basename(p) for p in pdf_files],
-            [os.path.basename(p) for p in pksim_files],
-        )
-        content = content + "\n" + download_block
-
-        dest_md = os.path.join(dest, "index.md")
         with open(dest_md, "w", encoding="utf-8") as fh:
-            fh.write(content)
+            fh.write(content + "\n" + download_block)
     else:
-        # Fallback: create a minimal index page
-        dest_md = os.path.join(dest, "index.md")
         with open(dest_md, "w", encoding="utf-8") as fh:
-            fh.write(f"# {folder_name}\n")
-            download_block = make_download_buttons(
-                folder_name,
-                [os.path.basename(p) for p in pdf_files],
-                [os.path.basename(p) for p in pksim_files],
-            )
-            fh.write(download_block)
+            fh.write(f"# {folder_name}\n" + download_block)
 
+    return {
+        "name":        folder_name,
+        "pdf_files":   pdf_basenames,
+        "pksim_files": pksim_basenames,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Home page (index.md)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def generate_index_md(chapters_data: list, docs_dir: str) -> None:
+    """Generate docs/index.md listing all compounds with download links."""
+    lines = [
+        "# OSP PBPK Model Library",
+        "",
+        "Library of released PBPK substance models and evaluation reports from the"
+        " [Open Systems Pharmacology](https://www.open-systems-pharmacology.org/) project.",
+        "",
+        "## Available Reports",
+        "",
+        "| Compound | PDF Report | PBPK Model File(s) |",
+        "|----------|:----------:|:------------------:|",
+    ]
+
+    for ch in sorted(chapters_data, key=lambda x: x["name"].lower()):
+        name = ch["name"]
+        base = f"{name}/"
+
+        pdf_cell = " ".join(
+            f'[:material-file-pdf-box: {pdf}]({base}{pdf}){{: download="{pdf}" }}'
+            for pdf in ch["pdf_files"]
+        ) or "—"
+
+        pksim_cell = " ".join(
+            f'[:material-download: {pksim}]({base}{pksim}){{: download="{pksim}" }}'
+            for pksim in ch["pksim_files"]
+        ) or "—"
+
+        lines.append(f"| [{name}]({base}index.md) | {pdf_cell} | {pksim_cell} |")
+
+    lines.append("")
+
+    with open(os.path.join(docs_dir, "index.md"), "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# MkDocs configuration
+# ──────────────────────────────────────────────────────────────────────────────
 
 def build_nav(chapters: list) -> list:
     """Build the MkDocs nav list."""
@@ -116,10 +266,9 @@ def build_nav(chapters: list) -> list:
     return nav
 
 
-def generate_mkdocs_yml(nav: list):
+def generate_mkdocs_yml(nav: list) -> None:
     """Write the mkdocs.yml configuration file."""
-    # Build the nav section using yaml for safe serialization
-    nav_yaml = yaml.dump({"nav": nav}, default_flow_style=False, allow_unicode=True)
+    nav_yaml  = yaml.dump({"nav": nav}, default_flow_style=False, allow_unicode=True)
     nav_block = nav_yaml[len("nav:"):].rstrip()
 
     content = f"""site_name: OSP PBPK Model Library
@@ -131,24 +280,29 @@ theme:
   name: material
   palette:
     - scheme: default
-      primary: teal
-      accent: teal
+      primary: blue
+      accent: blue
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - scheme: slate
-      primary: teal
-      accent: teal
+      primary: blue
+      accent: blue
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.tabs
+    - navigation.sections
     - navigation.top
+    - toc.follow
     - search.highlight
+    - search.suggest
     - content.code.copy
   icon:
     repo: fontawesome/brands/github
+
+extra_css:
+  - stylesheets/extra.css
 
 markdown_extensions:
   - attr_list
@@ -159,6 +313,7 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - toc:
       permalink: true
+      toc_depth: 3
 
 nav:{nav_block}
 """
@@ -167,22 +322,34 @@ nav:{nav_block}
         fh.write(content)
 
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Asset generation
+# ──────────────────────────────────────────────────────────────────────────────
+
+def generate_assets(docs_dir: str) -> None:
+    """Write extra CSS into docs/stylesheets/extra.css."""
+    css_dir = os.path.join(docs_dir, "stylesheets")
+    os.makedirs(css_dir, exist_ok=True)
+    with open(os.path.join(css_dir, "extra.css"), "w", encoding="utf-8") as fh:
+        fh.write(EXTRA_CSS)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
 def main():
     # Clean and recreate docs dir
     if os.path.exists(DOCS_DIR):
         shutil.rmtree(DOCS_DIR)
     os.makedirs(DOCS_DIR)
 
-    # Copy root README as index
-    readme = os.path.join(REPO_ROOT, "README.md")
-    if os.path.isfile(readme):
-        shutil.copy2(readme, os.path.join(DOCS_DIR, "index.md"))
-    else:
-        with open(os.path.join(DOCS_DIR, "index.md"), "w", encoding="utf-8") as fh:
-            fh.write("# OSP PBPK Model Library\n\nLibrary of released PBPK substance models and evaluation reports.\n")
+    # Write extra CSS
+    generate_assets(DOCS_DIR)
 
-    chapters = []
-    for entry in os.listdir(REPO_ROOT):
+    # Process each compound folder
+    chapters_data = []
+    for entry in sorted(os.listdir(REPO_ROOT)):
         if entry.startswith(EXCLUDE_PREFIXES):
             continue
         full_path = os.path.join(REPO_ROOT, entry)
@@ -190,10 +357,14 @@ def main():
             continue
         if not is_compound_folder(full_path):
             continue
-        process_folder(full_path, entry)
-        chapters.append(entry)
+        chapters_data.append(process_folder(full_path, entry))
 
-    nav = build_nav(chapters)
+    # Generate home page listing all reports
+    generate_index_md(chapters_data, DOCS_DIR)
+
+    # Build nav and write mkdocs.yml
+    chapters = [ch["name"] for ch in chapters_data]
+    nav      = build_nav(chapters)
     generate_mkdocs_yml(nav)
 
     print(f"Docs built: {len(chapters)} chapters → {DOCS_DIR}")

--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -272,7 +272,7 @@ def generate_mkdocs_yml(nav: list) -> None:
     nav_yaml  = yaml.dump({"nav": nav}, default_flow_style=False, allow_unicode=True)
     nav_block = nav_yaml[len("nav:"):].rstrip()
 
-    content = f"""site_name: OSP PBPK Model Library
+    content = f"""site_name: Open Systems Pharmacology PBPK Model Library
 site_description: Library of released PBPK substance models and evaluation reports
 docs_dir: docs
 site_dir: site

--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Build a MkDocs documentation site from the OSP-PBPK-Model-Library repository.
+
+Each top-level folder becomes a chapter. Markdown content is rendered as-is,
+with download buttons prepended for the PDF report and .pksim5 model files.
+"""
+
+import os
+import shutil
+import glob
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DOCS_DIR = os.path.join(REPO_ROOT, "docs")
+MKDOCS_YML = os.path.join(REPO_ROOT, "mkdocs.yml")
+
+# Folders to exclude (hidden directories and non-compound folders)
+EXCLUDE_PREFIXES = (".", "_")
+
+
+def is_compound_folder(path: str) -> bool:
+    """Return True if the folder contains a markdown evaluation report."""
+    for f in os.listdir(path):
+        if f.endswith(".md") and "evaluation_report" in f:
+            return True
+    return False
+
+
+def make_download_buttons(folder_name: str, pdf_files: list, pksim_files: list) -> str:
+    """Return an HTML block with download buttons for all assets."""
+    lines = [
+        "",
+        '<div class="download-section" markdown="1">',
+        "",
+        "## Downloads",
+        "",
+    ]
+    for pdf in sorted(pdf_files):
+        label = os.path.basename(pdf)
+        lines.append(
+            f'[:material-file-pdf-box: Download PDF Report]({label}){{: .md-button download="{label}" }}'
+        )
+        lines.append("")
+    for pksim in sorted(pksim_files):
+        label = os.path.basename(pksim)
+        lines.append(
+            f'[:material-download: Download PBPK Model ({label})]({label}){{: .md-button .md-button--primary download="{label}" }}'
+        )
+        lines.append("")
+    lines.append("</div>")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def process_folder(folder_path: str, folder_name: str):
+    """Copy and process one compound folder into docs/."""
+    dest = os.path.join(DOCS_DIR, folder_name)
+    os.makedirs(dest, exist_ok=True)
+
+    # Collect assets
+    md_files = glob.glob(os.path.join(folder_path, "*_evaluation_report.md"))
+    pdf_files = glob.glob(os.path.join(folder_path, "*.pdf"))
+    pksim_files = glob.glob(os.path.join(folder_path, "*.pksim5"))
+    images_dir = os.path.join(folder_path, "images")
+
+    # Copy images directory
+    if os.path.isdir(images_dir):
+        dest_images = os.path.join(dest, "images")
+        if os.path.exists(dest_images):
+            shutil.rmtree(dest_images)
+        shutil.copytree(images_dir, dest_images)
+
+    # Copy PDF files
+    for pdf in pdf_files:
+        shutil.copy2(pdf, dest)
+
+    # Copy .pksim5 files
+    for pksim in pksim_files:
+        shutil.copy2(pksim, dest)
+
+    # Process markdown — append download section
+    if md_files:
+        md_src = md_files[0]
+        with open(md_src, "r", encoding="utf-8") as fh:
+            content = fh.read()
+
+        download_block = make_download_buttons(
+            folder_name,
+            [os.path.basename(p) for p in pdf_files],
+            [os.path.basename(p) for p in pksim_files],
+        )
+        content = content + "\n" + download_block
+
+        dest_md = os.path.join(dest, "index.md")
+        with open(dest_md, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    else:
+        # Fallback: create a minimal index page
+        dest_md = os.path.join(dest, "index.md")
+        with open(dest_md, "w", encoding="utf-8") as fh:
+            fh.write(f"# {folder_name}\n")
+            download_block = make_download_buttons(
+                folder_name,
+                [os.path.basename(p) for p in pdf_files],
+                [os.path.basename(p) for p in pksim_files],
+            )
+            fh.write(download_block)
+
+
+def build_nav(chapters: list) -> list:
+    """Build the MkDocs nav list."""
+    nav = [{"Home": "index.md"}]
+    for chapter in sorted(chapters):
+        nav.append({chapter: f"{chapter}/index.md"})
+    return nav
+
+
+def generate_mkdocs_yml(nav: list):
+    """Write the mkdocs.yml configuration file."""
+    # Build the nav section using yaml for safe serialization
+    nav_yaml = yaml.dump({"nav": nav}, default_flow_style=False, allow_unicode=True)
+    nav_block = nav_yaml[len("nav:"):].rstrip()
+
+    content = f"""site_name: OSP PBPK Model Library
+site_description: Library of released PBPK substance models and evaluation reports
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - attr_list
+  - tables
+  - admonition
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+nav:{nav_block}
+"""
+
+    with open(MKDOCS_YML, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+def main():
+    # Clean and recreate docs dir
+    if os.path.exists(DOCS_DIR):
+        shutil.rmtree(DOCS_DIR)
+    os.makedirs(DOCS_DIR)
+
+    # Copy root README as index
+    readme = os.path.join(REPO_ROOT, "README.md")
+    if os.path.isfile(readme):
+        shutil.copy2(readme, os.path.join(DOCS_DIR, "index.md"))
+    else:
+        with open(os.path.join(DOCS_DIR, "index.md"), "w", encoding="utf-8") as fh:
+            fh.write("# OSP PBPK Model Library\n\nLibrary of released PBPK substance models and evaluation reports.\n")
+
+    chapters = []
+    for entry in os.listdir(REPO_ROOT):
+        if entry.startswith(EXCLUDE_PREFIXES):
+            continue
+        full_path = os.path.join(REPO_ROOT, entry)
+        if not os.path.isdir(full_path):
+            continue
+        if not is_compound_folder(full_path):
+            continue
+        process_folder(full_path, entry)
+        chapters.append(entry)
+
+    nav = build_nav(chapters)
+    generate_mkdocs_yml(nav)
+
+    print(f"Docs built: {len(chapters)} chapters → {DOCS_DIR}")
+    print(f"MkDocs config written → {MKDOCS_YML}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -165,16 +165,16 @@ def process_folder(folder_path: str, folder_name: str) -> dict:
     pdf_basenames   = sorted(os.path.basename(p) for p in pdf_files)
     pksim_basenames = sorted(os.path.basename(p) for p in pksim_files)
 
-     # Write index.md from the evaluation report
-     dest_md = os.path.join(dest, "index.md")
-     if md_files:
-         with open(sorted(md_files)[0], "r", encoding="utf-8") as fh:
-             content = fh.read()
-         with open(dest_md, "w", encoding="utf-8") as fh:
-             fh.write(content)
-     else:
-         with open(dest_md, "w", encoding="utf-8") as fh:
-             fh.write(f"# {folder_name}\n")
+    # Write index.md from the evaluation report
+    dest_md = os.path.join(dest, "index.md")
+    if md_files:
+        with open(sorted(md_files)[0], "r", encoding="utf-8") as fh:
+            content = fh.read()
+        with open(dest_md, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    else:
+        with open(dest_md, "w", encoding="utf-8") as fh:
+            fh.write(f"# {folder_name}\n")
 
     return {
         "name":        folder_name,

--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -165,6 +165,17 @@ def process_folder(folder_path: str, folder_name: str) -> dict:
     pdf_basenames   = sorted(os.path.basename(p) for p in pdf_files)
     pksim_basenames = sorted(os.path.basename(p) for p in pksim_files)
 
+     # Write index.md from the evaluation report
+     dest_md = os.path.join(dest, "index.md")
+     if md_files:
+         with open(sorted(md_files)[0], "r", encoding="utf-8") as fh:
+             content = fh.read()
+         with open(dest_md, "w", encoding="utf-8") as fh:
+             fh.write(content)
+     else:
+         with open(dest_md, "w", encoding="utf-8") as fh:
+             fh.write(f"# {folder_name}\n")
+
     return {
         "name":        folder_name,
         "pdf_files":   pdf_basenames,

--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -131,35 +131,6 @@ def is_compound_folder(path: str) -> bool:
             return True
     return False
 
-
-def make_download_buttons(pdf_files: list, pksim_files: list) -> str:
-    """Return a Markdown block with download buttons for all assets."""
-    lines = [
-        "",
-        '<div class="download-section" markdown="1">',
-        "",
-        "## Downloads",
-        "",
-    ]
-    for pdf in sorted(pdf_files):
-        label = os.path.basename(pdf)
-        lines.append(
-            f'[:material-file-pdf-box: Download PDF Report]({label})'
-            f'{{: .md-button download="{label}" }}'
-        )
-        lines.append("")
-    for pksim in sorted(pksim_files):
-        label = os.path.basename(pksim)
-        lines.append(
-            f'[:material-download: Download PBPK Model ({label})]({label})'
-            f'{{: .md-button .md-button--primary download="{label}" }}'
-        )
-        lines.append("")
-    lines.append("</div>")
-    lines.append("")
-    return "\n".join(lines)
-
-
 # ──────────────────────────────────────────────────────────────────────────────
 # Per-compound processing
 # ──────────────────────────────────────────────────────────────────────────────
@@ -194,20 +165,6 @@ def process_folder(folder_path: str, folder_name: str) -> dict:
     pdf_basenames   = sorted(os.path.basename(p) for p in pdf_files)
     pksim_basenames = sorted(os.path.basename(p) for p in pksim_files)
 
-    has_assets = bool(pdf_basenames or pksim_basenames)
-    download_block = make_download_buttons(pdf_basenames, pksim_basenames) if has_assets else ""
-
-    # Write index.md (report content + download section)
-    dest_md = os.path.join(dest, "index.md")
-    if md_files:
-        with open(sorted(md_files)[0], "r", encoding="utf-8") as fh:
-            content = fh.read()
-        with open(dest_md, "w", encoding="utf-8") as fh:
-            fh.write(content + ("\n" + download_block if has_assets else ""))
-    else:
-        with open(dest_md, "w", encoding="utf-8") as fh:
-            fh.write(f"# {folder_name}\n" + download_block)
-
     return {
         "name":        folder_name,
         "pdf_files":   pdf_basenames,
@@ -222,7 +179,7 @@ def process_folder(folder_path: str, folder_name: str) -> dict:
 def generate_index_md(chapters_data: list, docs_dir: str) -> None:
     """Generate docs/index.md listing all compounds with download links."""
     lines = [
-        "# OSP PBPK Model Library",
+        "# Open Systems Pharmacology PBPK Model Library",
         "",
         "Library of released PBPK substance models and evaluation reports from the"
         " [Open Systems Pharmacology](https://www.open-systems-pharmacology.org/) project.",

--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -194,15 +194,16 @@ def process_folder(folder_path: str, folder_name: str) -> dict:
     pdf_basenames   = sorted(os.path.basename(p) for p in pdf_files)
     pksim_basenames = sorted(os.path.basename(p) for p in pksim_files)
 
-    download_block = make_download_buttons(pdf_basenames, pksim_basenames)
+    has_assets = bool(pdf_basenames or pksim_basenames)
+    download_block = make_download_buttons(pdf_basenames, pksim_basenames) if has_assets else ""
 
     # Write index.md (report content + download section)
     dest_md = os.path.join(dest, "index.md")
     if md_files:
-        with open(md_files[0], "r", encoding="utf-8") as fh:
+        with open(sorted(md_files)[0], "r", encoding="utf-8") as fh:
             content = fh.read()
         with open(dest_md, "w", encoding="utf-8") as fh:
-            fh.write(content + "\n" + download_block)
+            fh.write(content + ("\n" + download_block if has_assets else ""))
     else:
         with open(dest_md, "w", encoding="utf-8") as fh:
             fh.write(f"# {folder_name}\n" + download_block)
@@ -228,8 +229,8 @@ def generate_index_md(chapters_data: list, docs_dir: str) -> None:
         "",
         "## Available Reports",
         "",
-        "| Compound | PDF Report | PBPK Model File(s) |",
-        "|----------|:----------:|:------------------:|",
+        "| Compound (HTML Report) | PDF Report | PK-Sim Project File(s) |",
+        "|------------------------|:----------:|:----------------------:|",
     ]
 
     for ch in sorted(chapters_data, key=lambda x: x["name"].lower()):

--- a/.github/workflows/generate-ghpages.yml
+++ b/.github/workflows/generate-ghpages.yml
@@ -2,6 +2,8 @@ name: Generate GitHub Pages
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: write

--- a/.github/workflows/generate-ghpages.yml
+++ b/.github/workflows/generate-ghpages.yml
@@ -14,12 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/generate-ghpages.yml
+++ b/.github/workflows/generate-ghpages.yml
@@ -1,0 +1,47 @@
+name: Generate GitHub Pages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install MkDocs and dependencies
+        run: |
+          pip install \
+            mkdocs \
+            mkdocs-material \
+            pymdown-extensions \
+            pyyaml
+
+      - name: Build docs structure
+        run: python .github/scripts/build_docs.py
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy OSP PBPK Model Library docs'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# MkDocs generated files (created by the generate-ghpages workflow)
+docs/
+site/
+mkdocs.yml


### PR DESCRIPTION
@Yuri05 

Based on discussion from #393

Workflow in PR renders the following result: https://pchelle.github.io/OSP-PBPK-Model-Library/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Automated doc site with custom Material styling (blue theme, responsive nav, highlighted TOC, download button spacing)
  * Content organized into chapters per compound with embedded images and downloadable PDF/PK‑Sim assets
  * Home index lists all compounds with inline download links; site built strictly for accuracy and reproducibility

* **Chores**
  * CI workflow to build and publish the docs to GitHub Pages
  * Repository ignores generated docs and site files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->